### PR TITLE
feat(ui): add VpnStatusBadge and card

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ NODE_ENV=development
 | **Frontend** | *“Create a `<VpnStatusBadge />` component that shows the status (`online`, `offline`, `warning`) with the existing colour palette.”* |
 | **Testing** | *“Write Jest tests to cover the new restart route (happy + error paths).”* |
 | **Docs** | *“Generate Swagger docs for all `/api/vpn/*` endpoints and expose them at `/api/docs`.”* |
+| **UI** | *"Create `<VpnStatusBadge />` component"* |
 
 When working on tasks the agent **must**:
 - Pass `npm run lint` and `npm test`.

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -10,3 +10,7 @@
 - Добавлена поддержка JWT и таблицы `Vpn`, `Job` (пока в памяти).
 - Реализован эндпоинт `POST /api/vpn/restart/:id`.
 - Добавлена документация Swagger и тесты на Jest.
+
+## 2025-06-28
+- Создан компонент `VpnStatusBadge` и карточка `VpnCard` на TypeScript.
+- Добавлены тесты на React Testing Library и обновлён Jest конфиг.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,8 @@ module.exports = [
     languageOptions: {
       parserOptions: {
         ecmaVersion: 2020,
-        sourceType: 'module'
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true }
       },
       globals: {
         window: 'readonly',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,9 @@
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/server'],
+  testEnvironment: 'jsdom',
+  roots: ['<rootDir>/server', '<rootDir>/src'],
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
   globals: {
-    'ts-jest': { tsconfig: '<rootDir>/server/tsconfig.json' }
+    'ts-jest': { tsconfig: '<rootDir>/tsconfig.json' }
   }
 };

--- a/src/components/Admin/AdminPanel.jsx
+++ b/src/components/Admin/AdminPanel.jsx
@@ -1,4 +1,4 @@
-AdminPanel.jsx - Административная панель
+// AdminPanel.jsx - Административная панель
 
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '../../contexts/AuthContext';

--- a/src/components/Settings/SettingsPage.jsx
+++ b/src/components/Settings/SettingsPage.jsx
@@ -1,4 +1,4 @@
-SettingsPage.jsx - Страница настроек пользователя
+// SettingsPage.jsx - Страница настроек пользователя
 
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '../../contexts/AuthContext';

--- a/src/components/VpnCard.tsx
+++ b/src/components/VpnCard.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { RotateCcw, Loader } from 'lucide-react';
+import VpnStatusBadge from './VpnStatusBadge';
+import { Vpn, VpnStatus } from '../types/vpn';
+
+interface VpnCardProps {
+  vpn: Vpn;
+  jwt: string;
+}
+
+const VpnCard: React.FC<VpnCardProps> = ({ vpn, jwt }) => {
+  const [status, setStatus] = useState<VpnStatus>(vpn.status);
+  const [loading, setLoading] = useState(false);
+
+  const handleRestart = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/vpn/restart/' + vpn.id, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer ' + jwt }
+      });
+      if (res.ok) {
+        setStatus('pending');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="card space-y-2">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-white flex items-center gap-2">
+          {vpn.name}
+          <VpnStatusBadge status={status} />
+        </h3>
+      </div>
+      <button
+        className="btn-primary flex items-center gap-1"
+        onClick={handleRestart}
+        disabled={loading}
+      >
+        {loading ? (
+          <Loader className="w-4 h-4 animate-spin" />
+        ) : (
+          <RotateCcw className="w-4 h-4" />
+        )}
+        Restart
+      </button>
+    </div>
+  );
+};
+
+export default VpnCard;

--- a/src/components/VpnStatusBadge.tsx
+++ b/src/components/VpnStatusBadge.tsx
@@ -1,0 +1,45 @@
+import { CheckCircle, CircleOff, AlertTriangle, Loader } from 'lucide-react';
+import React from 'react';
+
+export interface VpnStatusBadgeProps {
+  status: 'online' | 'offline' | 'warning' | 'pending';
+}
+
+const map = {
+  online: {
+    bg: 'bg-green-100',
+    text: 'text-green-700',
+    Icon: CheckCircle
+  },
+  offline: {
+    bg: 'bg-red-100',
+    text: 'text-red-700',
+    Icon: CircleOff
+  },
+  warning: {
+    bg: 'bg-yellow-100',
+    text: 'text-yellow-800',
+    Icon: AlertTriangle
+  },
+  pending: {
+    bg: 'bg-slate-100',
+    text: 'text-slate-600',
+    Icon: Loader
+  }
+} as const;
+
+const VpnStatusBadge: React.FC<VpnStatusBadgeProps> = ({ status }) => {
+  const { bg, text, Icon } = map[status];
+  const extra = status === 'pending' ? 'animate-pulse' : '';
+  const iconClasses = status === 'pending' ? 'w-4 h-4 animate-spin' : 'w-4 h-4';
+  return (
+    <span
+      className={`flex items-center gap-1.5 px-2 py-0.5 rounded-full text-sm font-medium ${bg} ${text} ${extra}`}
+    >
+      <Icon className={iconClasses} />
+      {status}
+    </span>
+  );
+};
+
+export default VpnStatusBadge;

--- a/src/components/__tests__/VpnCard.test.tsx
+++ b/src/components/__tests__/VpnCard.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import VpnCard from '../VpnCard';
+import { Vpn } from '../../types/vpn';
+
+global.fetch = jest.fn();
+
+const vpn: Vpn = {
+  id: '1',
+  name: 'Test VPN',
+  status: 'online',
+  createdAt: ''
+};
+
+describe('VpnCard', () => {
+  beforeEach(() => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: true });
+  });
+
+  it('calls restart and disables button', async () => {
+    render(<VpnCard vpn={vpn} jwt="token" />);
+    const btn = screen.getByRole('button', { name: /restart/i });
+    fireEvent.click(btn);
+    expect(fetch).toHaveBeenCalledWith('/api/vpn/restart/1', expect.objectContaining({ method: 'POST' }));
+    expect(btn).toBeDisabled();
+    await waitFor(() => expect(btn).not.toBeDisabled());
+  });
+});

--- a/src/components/__tests__/VpnStatusBadge.test.tsx
+++ b/src/components/__tests__/VpnStatusBadge.test.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import VpnStatusBadge from '../VpnStatusBadge';
+import { VpnStatus } from '../../types/vpn';
+
+describe('VpnStatusBadge snapshots', () => {
+  const statuses: VpnStatus[] = ['online', 'offline', 'warning', 'pending'];
+  statuses.forEach(status => {
+    it(`renders ${status}`, () => {
+      const { container } = render(<VpnStatusBadge status={status} />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/types/vpn.ts
+++ b/src/types/vpn.ts
@@ -1,0 +1,8 @@
+export type VpnStatus = 'online' | 'offline' | 'warning' | 'pending';
+
+export interface Vpn {
+  id: string;
+  name: string;
+  status: VpnStatus;
+  createdAt: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "noEmit": true
+  },
+  "include": ["src", "server/src", "server/test"]
+}


### PR DESCRIPTION
## Summary
- implement `VpnStatusBadge` component
- create `VpnCard` with restart button
- configure Jest for frontend tests
- add TypeScript config and definitions
- document new components in development log
- update AGENTS guidelines with UI example

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4014bf508332bee76af93281a624