### PR TITLE
feat(config): admin-editable xray template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 server/dist/
 package-lock.json
 .env
+configs/

--- a/TECH_SPEC.md
+++ b/TECH_SPEC.md
@@ -7,3 +7,7 @@
 Пайплайн GitHub Actions выполняет lint и тесты, затем собирает и публикует Docker‑образы в GHCR. При пуше в ветку `main` приложения деплоятся на Fly.io. Любая ветка `release/*` запускает обновление образов в Kubernetes.
 
 Мониторинг реализован через Prometheus и Grafana. Бекенд предоставляет endpoint `/metrics` с метриками `http_requests_total` и `process_cpu_seconds_total`. Helm‑chart `prometheus-stack` конфигурируется значениями из каталога `k8s/monitoring/`.
+
+## Config template editing
+
+Файл шаблона конфигурации VPN хранится в таблице `ConfigTemplate` (см. Prisma schema) и дублируется на диске `server/config-template.json`. Админ может получить и изменить шаблон через `/api/admin/config-template`. После оплаты подписки веб‑хук Stripe создаёт пользовательский конфиг в `configs/<userId>.json`, подставляя `uuid` пользователя вместо `{{USER_UUID}}`.

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -27,3 +27,5 @@
 
 ## 2025-06-30b
 - Подготовлены Dockerfile и docker-compose. Настроен CI/CD с Fly.io и Kubernetes. Добавлен monitoring через Prometheus и Grafana.
+## 2025-06-27b
+- Реализовано редактирование шаблона конфигурации и генерация файла после оплаты.

--- a/server/config-template.json
+++ b/server/config-template.json
@@ -1,0 +1,14 @@
+{
+  "v": "2",
+  "ps": "My-VPN",
+  "add": "vpn.example.com",
+  "port": 443,
+  "id": "{{USER_UUID}}",
+  "aid": 0,
+  "scy": "auto",
+  "net": "tcp",
+  "type": "none",
+  "host": "",
+  "path": "",
+  "tls": "tls"
+}

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -158,3 +158,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Vpn'
+  /api/config:
+    get:
+      summary: Download VPN config
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Config file
+          content:
+            application/json:
+              schema:
+                type: object
+        '402':
+          description: Subscription required
+  /api/admin/config-template:
+    get:
+      summary: Get config template
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Template JSON
+          content:
+            application/json:
+              schema:
+                type: object
+    put:
+      summary: Update config template
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Updated template
+          content:
+            application/json:
+              schema:
+                type: object

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -9,13 +9,29 @@
   provider = "prisma-client-js"
  }
 
- model User {
-   id       String  @id @default(cuid())
-   email    String  @unique
-   password String
-   role     Role    @default(USER)
-   Vpn      Vpn[]
- }
+model User {
+  id          String   @id @default(cuid())
+  email       String   @unique
+  password    String
+  uuid        String   @unique
+  role        Role     @default(USER)
+  Subscription Subscription?
+  Vpn         Vpn[]
+}
+
+model Subscription {
+  id       String  @id @default(cuid())
+  user     User    @relation(fields: [userId], references: [id])
+  userId   String  @unique
+  status   String
+  stripeId String?
+}
+
+model ConfigTemplate {
+  id        Int      @id @default(1)
+  json      Json
+  updatedAt DateTime @updatedAt
+}
 
  model Vpn {
    id        String @id @default(cuid())

--- a/server/src/configRoutes.ts
+++ b/server/src/configRoutes.ts
@@ -1,0 +1,66 @@
+import { Router } from 'express';
+import fs from 'fs';
+import path from 'path';
+import { authenticateJWT, authorizeRoles, AuthenticatedRequest } from './auth';
+import { Role } from './types';
+import { users, subscriptions, configTemplate } from './store';
+
+const router = Router();
+
+router.get('/config', authenticateJWT, (req: AuthenticatedRequest, res) => {
+  const userId = req.user!.id;
+  const sub = subscriptions[userId];
+  if (!sub || sub.status !== 'active') {
+    return res.status(402).json({ error: 'Subscription inactive' });
+  }
+  const file = path.join(__dirname, '../../configs', `${userId}.json`);
+  if (!fs.existsSync(file)) {
+    return res.status(404).json({ error: 'Config not found' });
+  }
+  res.setHeader('Content-Disposition', 'attachment; filename="myvpn.json"');
+  res.sendFile(file);
+});
+
+router.get(
+  '/admin/config-template',
+  authenticateJWT,
+  authorizeRoles(Role.ADMIN),
+  (_req, res) => {
+    res.json(configTemplate);
+  }
+);
+
+router.put(
+  '/admin/config-template',
+  authenticateJWT,
+  authorizeRoles(Role.ADMIN),
+  (req, res) => {
+    if (typeof req.body !== 'object' || Array.isArray(req.body)) {
+      return res.status(400).json({ error: 'Invalid JSON' });
+    }
+    Object.assign(configTemplate, req.body);
+    const p = path.join(__dirname, '../config-template.json');
+    fs.writeFileSync(p, JSON.stringify(configTemplate, null, 2));
+    res.json(configTemplate);
+  }
+);
+
+router.post('/stripe/webhook', (req, res) => {
+  const { type, data } = req.body as { type: string; data: any };
+  if (type === 'checkout.session.completed') {
+    const userId = data.userId as string;
+    const user = users.find(u => u.id === userId);
+    if (user) {
+      subscriptions[userId] = { status: 'active' };
+      const cfg = JSON.parse(
+        JSON.stringify(configTemplate).replace('{{USER_UUID}}', user.uuid)
+      );
+      const dir = path.join(__dirname, '../../configs');
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir);
+      fs.writeFileSync(path.join(dir, `${userId}.json`), JSON.stringify(cfg, null, 2));
+    }
+  }
+  res.json({ received: true });
+});
+
+export default router;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -8,6 +8,7 @@ import pinoHttp from 'pino-http';
 import client from 'prom-client';
 import vpnRouter from './vpn';
 import authRouter from './authRoutes';
+import configRouter from './configRoutes';
 
 export const app = express();
 
@@ -48,3 +49,4 @@ app.get('/metrics', async (_req, res) => {
 
 app.use('/api/auth', authRouter);
 app.use('/api/vpn', vpnRouter);
+app.use('/api', configRouter);

--- a/server/src/store.ts
+++ b/server/src/store.ts
@@ -1,21 +1,26 @@
 import bcrypt from 'bcryptjs';
+import fs from 'fs';
+import path from 'path';
 import { Job, Role, User, Vpn } from './types';
 
 export const users: User[] = [
   {
     id: 'u1',
+    uuid: 'uuid-u1',
     email: 'admin@test.com',
     password: bcrypt.hashSync('admin', 8),
     role: Role.ADMIN
   },
   {
     id: 'u2',
+    uuid: 'uuid-u2',
     email: 'user@test.com',
     password: bcrypt.hashSync('user', 8),
     role: Role.USER
   },
   {
     id: 'u3',
+    uuid: 'uuid-u3',
     email: 'viewer@test.com',
     password: bcrypt.hashSync('viewer', 8),
     role: Role.VIEWER
@@ -26,6 +31,34 @@ export const vpns: Vpn[] = [
   { id: '1', ownerId: 'u1', name: 'First VPN', tariffId: 't1' },
   { id: '2', ownerId: 'u2', name: 'Second VPN', tariffId: 't2' }
 ];
+
+export const subscriptions: Record<string, { status: string }> = {
+  u1: { status: 'inactive' },
+  u2: { status: 'inactive' },
+  u3: { status: 'inactive' }
+};
+
+export let configTemplate: any = {
+  v: '2',
+  ps: 'My-VPN',
+  add: 'vpn.example.com',
+  port: 443,
+  id: '{{USER_UUID}}',
+  aid: 0,
+  scy: 'auto',
+  net: 'tcp',
+  type: 'none',
+  host: '',
+  path: '',
+  tls: 'tls'
+};
+
+const templatePath = path.join(__dirname, '../config-template.json');
+if (fs.existsSync(templatePath)) {
+  configTemplate = JSON.parse(fs.readFileSync(templatePath, 'utf-8'));
+} else {
+  fs.writeFileSync(templatePath, JSON.stringify(configTemplate, null, 2));
+}
 
 export const jobs: Job[] = [];
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -8,7 +8,14 @@ export interface User {
   id: string;
   email: string;
   password: string;
+  uuid: string;
   role: Role;
+  subscription?: Subscription;
+}
+
+export interface Subscription {
+  status: string;
+  stripeId?: string;
 }
 
 export interface Vpn {

--- a/server/test/configTemplate.spec.ts
+++ b/server/test/configTemplate.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment node
+ */
+import request from 'supertest';
+import { app } from '../src/server';
+import { signAccessToken } from '../src/auth';
+import { Role } from '../src/types';
+import fs from 'fs';
+import { configTemplate } from '../src/store';
+
+const adminToken = signAccessToken({ id: 'u1', role: Role.ADMIN });
+const userToken = signAccessToken({ id: 'u2', role: Role.USER });
+
+describe('Config template admin routes', () => {
+  it('admin can get template', async () => {
+    const res = await request(app)
+      .get('/api/admin/config-template')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toBeDefined();
+  });
+
+  it('user forbidden', async () => {
+    const res = await request(app)
+      .get('/api/admin/config-template')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('admin can update template', async () => {
+    const res = await request(app)
+      .put('/api/admin/config-template')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ foo: 'bar' });
+    expect(res.status).toBe(200);
+    expect(res.body.foo).toBe('bar');
+  });
+});
+
+describe('Webhook generation', () => {
+  const configPath = `configs/u2.json`;
+  afterAll(() => {
+    if (fs.existsSync(configPath)) fs.unlinkSync(configPath);
+  });
+
+  beforeAll(() => {
+    Object.assign(configTemplate, {
+      v: '2',
+      ps: 'My-VPN',
+      add: 'vpn.example.com',
+      port: 443,
+      id: '{{USER_UUID}}',
+      aid: 0,
+      scy: 'auto',
+      net: 'tcp',
+      type: 'none',
+      host: '',
+      path: '',
+      tls: 'tls'
+    });
+    if (fs.existsSync(configPath)) fs.unlinkSync(configPath);
+  });
+
+  it('creates file with uuid', async () => {
+    const res = await request(app)
+      .post('/api/stripe/webhook')
+      .send({ type: 'checkout.session.completed', data: { userId: 'u2' } });
+    expect(res.status).toBe(200);
+    const data = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    expect(data.id).toBe('uuid-u2');
+  });
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import Dashboard from './components/Dashboard/Dashboard';
 import SubscriptionPage from './components/Subscription/SubscriptionPage';
 import SettingsPage from './components/Settings/SettingsPage';
 import AdminPanel from './components/Admin/AdminPanel';
+import ConfigTemplatePage from './components/Admin/ConfigTemplatePage';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { ToastProvider } from './contexts/ToastContext';
 import LoadingSpinner from './components/Common/LoadingSpinner';
@@ -112,13 +113,22 @@ const AppContent = () => {
             } 
           />
           
-          <Route 
-            path="/admin" 
+          <Route
+            path="/admin"
             element={
               <ProtectedRoute requireAdmin={true}>
                 <AdminPanel />
               </ProtectedRoute>
-            } 
+            }
+          />
+
+          <Route
+            path="/admin/config"
+            element={
+              <ProtectedRoute requireAdmin={true}>
+                <ConfigTemplatePage />
+              </ProtectedRoute>
+            }
           />
           
           {/* Редирект на главную */}

--- a/src/components/Admin/ConfigTemplatePage.jsx
+++ b/src/components/Admin/ConfigTemplatePage.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { Download } from 'lucide-react';
+import { useAuth } from '../../hooks/useAuth';
+
+const ConfigTemplatePage = () => {
+  const { user } = useAuth();
+  const [value, setValue] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (user?.role === 'admin') {
+      fetch('/api/admin/config-template')
+        .then(r => r.json())
+        .then(data => setValue(JSON.stringify(data, null, 2)));
+    }
+  }, [user]);
+
+  const save = async () => {
+    try {
+      const json = JSON.parse(value);
+      await fetch('/api/admin/config-template', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(json)
+      });
+      setError('');
+    } catch (e) {
+      setError('Неверный JSON');
+    }
+  };
+
+  if (user?.role !== 'admin') {
+    return <div className="p-4 text-red-500">403 Forbidden</div>;
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      {error && <div className="text-red-500">{error}</div>}
+      <textarea
+        className="w-full h-64 p-2 text-sm text-gray-900"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+      />
+      <button onClick={save} className="bg-blue-600 text-white px-4 py-2 rounded">
+        Save
+      </button>
+    </div>
+  );
+};
+
+export default ConfigTemplatePage;

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -125,6 +125,13 @@ const Dashboard = () => {
                   Действует до: {new Date(user.subscription.expires_at).toLocaleDateString('ru-RU')}
                 </p>
               </div>
+              <button
+                onClick={() => window.open('/api/config')}
+                className="ml-auto bg-blue-600 hover:bg-blue-700 text-white px-3 py-1.5 rounded flex items-center"
+                disabled={!hasActiveSubscription}
+              >
+                <Download className="w-4 h-4 mr-1" />Скачать конфиг
+              </button>
             </div>
           ) : (
             <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4 flex items-center justify-between">

--- a/src/components/__tests__/AdminConfigPage.test.tsx
+++ b/src/components/__tests__/AdminConfigPage.test.tsx
@@ -1,0 +1,24 @@
+/** @jest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+
+describe('ConfigTemplatePage', () => {
+  it('renders textarea for admin', async () => {
+    jest.doMock('../../hooks/useAuth', () => ({
+      useAuth: () => ({ user: { role: 'admin' } })
+    }));
+    const { default: Page } = await import('../Admin/ConfigTemplatePage');
+    render(<Page />);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    jest.dontMock('../../hooks/useAuth');
+  });
+
+  it('shows forbidden for user', async () => {
+    jest.doMock('../../hooks/useAuth', () => ({
+      useAuth: () => ({ user: { role: 'user' } })
+    }));
+    const { default: Page } = await import('../Admin/ConfigTemplatePage');
+    render(<Page />);
+    expect(screen.getByText(/403/i)).toBeInTheDocument();
+    jest.dontMock('../../hooks/useAuth');
+  });
+});


### PR DESCRIPTION
## Summary
- store Xray config template and subscription state
- deliver config file via `/api/config`
- admin endpoints to read/update template
- generate config on Stripe webhook
- add minimal admin editor page and download button
- update Prisma schema, docs and tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d620561808332b43e5cffc4bc0d81