### PR TITLE
Add security middleware with rate limit & helmet

### DIFF
--- a/TECH_SPEC.md
+++ b/TECH_SPEC.md
@@ -13,10 +13,13 @@
 
 Файл шаблона конфигурации VPN хранится в таблице `ConfigTemplate` (см. Prisma schema) и дублируется на диске `server/config-template.json`. Админ может получить и изменить шаблон через `/api/admin/config-template`. После оплаты подписки веб‑хук Stripe создаёт пользовательский конфиг в `configs/<userId>.json`, подставляя `uuid` пользователя вместо `{{USER_UUID}}`.
 
-## Observability & Security
+## Observability
 - Все HTTP запросы считаются и измеряются через Prometheus middleware. Метрики доступны без авторизации по `/metrics`.
 - Alertmanager настроен на Slack и Telegram, правило `HighErrorRate` срабатывает при доле 5xx >5% в течение 5 минут.
-- Сервер защищён через `express-rate-limit` (100 запросов за 15 минут на IP, кроме `/metrics`) и `helmet` с CSP `default-src 'self'`.
+
+## Security hardening
+- `helmet` со строгой Content-Security-Policy (`default-src 'self'; img-src 'self' data:; script-src 'self'; object-src 'none'`), `crossOriginEmbedderPolicy: false`.
+- `express-rate-limit` – 100 запросов за 15 минут на IP, исключая `/metrics` и `/health`.
 
 ## Database & Prisma
 - Используется PostgreSQL 15 и Prisma ORM 5.

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -57,3 +57,8 @@
 
 ## 2025-07-06
 - Настроен workflow ci.yml с PostgreSQL и Prisma, линт и тесты проходят.
+
+## 2025-07-07
+- Введены middleware security (helmet с CSP, глобальный rate-limit).
+- Обновлены Swagger и TECH_SPEC.
+

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -45,8 +45,16 @@ components:
           type: string
         tariffId:
           type: string
-security:
-  - bearerAuth: []
+  responses:
+    TooManyRequests:
+      description: Too many requests
+      headers:
+        Retry-After:
+          description: When to retry the request
+          schema:
+            type: string
+  security:
+    - bearerAuth: []
 paths:
   /api/auth/login:
     post:
@@ -64,6 +72,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Tokens'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
   /api/auth/refresh:
     post:
       summary: Refresh access token
@@ -86,6 +96,8 @@ paths:
                 properties:
                   access:
                     type: string
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
   /api/vpn:
     get:
       summary: List VPNs
@@ -100,6 +112,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Vpn'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
     post:
       summary: Create VPN
       security:
@@ -117,6 +131,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Vpn'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
   /api/vpn/{id}:
     patch:
       summary: Update VPN
@@ -141,6 +157,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Vpn'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
     delete:
       summary: Delete VPN
       security:
@@ -158,6 +176,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Vpn'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
   /api/config:
     get:
       summary: Download VPN config
@@ -172,6 +192,8 @@ paths:
                 type: object
         '402':
           description: Subscription required
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
   /api/admin/config-template:
     get:
       summary: Get config template
@@ -184,6 +206,8 @@ paths:
             application/json:
               schema:
                 type: object
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
     put:
       summary: Update config template
       security:
@@ -201,6 +225,8 @@ paths:
             application/json:
               schema:
                 type: object
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
 
   /metrics:
     get:
@@ -239,6 +265,8 @@ paths:
                 properties:
                   url:
                     type: string
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
 
   /api/billing/webhook:
     post:
@@ -250,6 +278,8 @@ paths:
             application/json:
               schema:
                 type: object
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
 
   /api/subscription-url:
     get:
@@ -268,6 +298,8 @@ paths:
                     type: string
         '402':
           description: Subscription required
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
 
   /api/admin/subscription-template:
     get:
@@ -284,6 +316,8 @@ paths:
                 properties:
                   urlTemplate:
                     type: string
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
     put:
       summary: Update subscription link template
       security:
@@ -307,3 +341,5 @@ paths:
                 properties:
                   urlTemplate:
                     type: string
+        '429':
+          $ref: '#/components/responses/TooManyRequests'

--- a/server/src/middleware/security.ts
+++ b/server/src/middleware/security.ts
@@ -1,0 +1,26 @@
+import rateLimit from 'express-rate-limit';
+import helmet from 'helmet';
+
+export const securityMiddlewares = [
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        imgSrc: ["'self'", 'data:'],
+        scriptSrc: ["'self'"],
+        objectSrc: ["'none'"],
+        upgradeInsecureRequests: [],
+      },
+    },
+    crossOriginEmbedderPolicy: false,
+  }),
+  rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 100,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: req =>
+      req.path.startsWith('/metrics') ||
+      req.path.startsWith('/health'),
+  }),
+];

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -5,8 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import pino from 'pino';
 import pinoHttp from 'pino-http';
-import helmet from 'helmet';
-import rateLimit from 'express-rate-limit';
+import { securityMiddlewares } from './middleware/security';
 import { register } from './metrics';
 import { metricsMiddleware } from './metricsMiddleware';
 import vpnRouter from './vpn';
@@ -23,22 +22,7 @@ app.use(pinoHttp({ logger }));
 app.use(cors());
 app.use('/api/billing/webhook', express.raw({ type: 'application/json' }));
 app.use(express.json());
-app.use(
-  helmet({
-    contentSecurityPolicy: {
-      directives: {
-        defaultSrc: ["'self'"]
-      }
-    }
-  })
-);
-app.use(
-  rateLimit({
-    windowMs: 15 * 60 * 1000,
-    max: 100,
-    skip: req => req.path === '/metrics'
-  })
-);
+securityMiddlewares.forEach(mw => app.use(mw));
 
 app.use(metricsMiddleware);
 

--- a/server/test/security.spec.ts
+++ b/server/test/security.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+import request from 'supertest';
+import createPrismaMock from 'prisma-mock';
+import { mockReset } from 'jest-mock-extended';
+import { Prisma } from '@prisma/client';
+
+process.env.STRIPE_SECRET_KEY = 'sk_test';
+jest.mock('../src/lib/prisma', () => ({ prisma: createPrismaMock({}, (Prisma as any).dmmf.datamodel) }));
+import { prisma } from '../src/lib/prisma';
+import { app } from '../src/server';
+import { signAccessToken } from '../src/auth';
+import { Role } from '../src/types';
+
+beforeEach(() => {
+  mockReset(prisma);
+  app.set('trust proxy', true);
+});
+
+describe('Security middleware', () => {
+  it('rate limits after 100 requests', async () => {
+    const token = signAccessToken({ id: 'u1', role: Role.USER });
+    for (let i = 0; i < 100; i++) {
+      await request(app)
+        .get('/api/vpn')
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Forwarded-For', '1.1.1.1');
+    }
+    const res = await request(app)
+      .get('/api/vpn')
+      .set('Authorization', `Bearer ${token}`)
+      .set('X-Forwarded-For', '1.1.1.1');
+    expect(res.status).toBe(429);
+    expect(res.headers['retry-after']).toBeDefined();
+  });
+
+  it('/metrics is not rate limited', async () => {
+    let res: request.Response | undefined;
+    for (let i = 0; i < 101; i++) {
+      res = await request(app)
+        .get('/metrics')
+        .set('X-Forwarded-For', '2.2.2.2');
+    }
+    expect(res!.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- add global security middlewares (helmet & express-rate-limit)
- import them in the server setup
- document 429 responses in Swagger spec
- create Jest tests for rate limiting and metrics skip
- update technical spec with Security hardening section
- log the change in development diary

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d9ff9eaf48332a2135bb3319f74fc