### PR TITLE
Fix server Dockerfile build script

### DIFF
--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -174,3 +174,7 @@
 - В `docker-compose.yml` добавлена общая сеть `app`, все сервисы подключены к
   ней. Nginx зависит от backend и frontend.
 - Обновлён пример `.env` и документация.
+## 2025-08-06
+- Добавлен `server/package.json` с командой `build:server`.
+- Dockerfile сервера теперь использует `pnpm run build:server`.
+

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,7 +12,7 @@ COPY prisma ./prisma
 
 # Generate Prisma client before compiling
 RUN npx prisma generate
-RUN pnpm run build
+RUN pnpm run build:server
 
 # Remove dev dependencies
 RUN pnpm prune --prod

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "vpn-backend",
+  "private": true,
+  "scripts": {
+    "build:server": "tsc -p tsconfig.json"
+  }
+}


### PR DESCRIPTION
## Summary
- add build script in server package.json
- use `pnpm run build:server` in server Dockerfile
- log changes

## Testing
- `npm run lint`
- `npm test`
- `docker compose down` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686247777ac48332a1849f2fb23bf2bc