### PR TITLE
Fix Prisma schema in runtime image

### DIFF
--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -178,3 +178,7 @@
 - Добавлен `server/package.json` с командой `build:server`.
 - Dockerfile сервера теперь использует `pnpm run build:server`.
 
+
+## 2025-08-07
+- Исправлен Dockerfile сервера: на этапе runtime копируется каталог `prisma` для корректной работы `npx prisma`.
+

--- a/docs/logging-guidelines.md
+++ b/docs/logging-guidelines.md
@@ -32,3 +32,9 @@
 
 Данные рекомендации помогут отслеживать проблемы и сохранять историю для дальнейшего анализа.
 - Перед компиляцией сервера запускайте `prisma generate` и сохраняйте вывод в лог `logs/prisma_generate_<date>.log`.
+7. **Миграции в контейнере**
+   - При запуске backend выполняется `npx prisma migrate deploy`.
+   - Вывод команды фиксируйте:
+     ```bash
+     docker compose logs backend 2>&1 | tee logs/backend_migrate_$(date +%F).log
+     ```

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -21,5 +21,6 @@ FROM node:18-alpine
 WORKDIR /app
 COPY --from=build /app/server/dist ./dist
 COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/prisma ./prisma
 EXPOSE 4000
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- copy prisma schema into runtime layer in server Dockerfile
- document logging of prisma migrations
- record fix in development log

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68624e67a10c8332af6e4352dcdeae5f