### PR TITLE
Fix compose context and add docker CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,13 @@ jobs:
           docker logs backend | grep -qi "libssl" && exit 1
           docker logs nginx   | grep -q "host not found" && exit 1
           docker compose down
+
+  docker-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker compose build --no-cache
+      - run: docker compose up -d
+      - run: curl -sI http://localhost/static/js/main.js | grep -q "Content-Type: application/javascript"
+      - run: docker logs nginx   | (! grep -q "host not found")
+      - run: docker logs backend | (! grep -qi "libssl")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,10 +30,10 @@ services:
 
   backend:
     build:
-      context: ./server
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: server/Dockerfile
     env_file:
-      - .env
+      - ./.env
     depends_on:
       postgres:
         condition: service_healthy
@@ -51,7 +51,7 @@ services:
     build:
       context: .
       dockerfile: src/Dockerfile        # ← ваш Dockerfile с Vite-сборкой
-    env_file: .env
+    env_file: ./.env
     depends_on:
       backend:
         condition: service_started

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -235,3 +235,9 @@
 - Исправлены Dockerfile и docker-compose для корректной сборки на Debian 11.
 - Добавлен .dockerignore в каталог server.
 - Workflow CI проверяет MIME типы статики и отсутствие ошибок libssl/libhost.
+
+## 2025-08-19
+- Исправлены пути сборки backend и env-файл в docker-compose.
+- Dockerfile сервера копирует исходники из корня.
+- В CI добавлена проверка docker-test.
+

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,7 +7,9 @@ COPY package.json pnpm-lock.yaml ./
 RUN corepack enable && pnpm install --frozen-lockfile
 
 # исходники
-COPY . .
+COPY server ./server
+COPY prisma ./prisma
+COPY server/openapi.yaml ./openapi.yaml
 RUN pnpm run build:server
 RUN pnpm prisma generate
 


### PR DESCRIPTION
## Summary
- fix backend build context in docker-compose and use .env from repo
- copy server sources in Dockerfile and keep libssl1.1 for runtime
- add docker-test workflow job
- update dev log

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68629ea293e08332baa5db13c6d4a962