### PR TITLE
fix: nginx upstream target

### DIFF
--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -241,3 +241,5 @@
 - Dockerfile сервера копирует исходники из корня.
 - В CI добавлена проверка docker-test.
 
+## 2025-08-20
+- Исправлен upstream Nginx: сервис frontend теперь указывается по имени из docker-compose.

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -18,6 +18,10 @@ http {
         server backend:4000;
     }
 
+    upstream frontend {
+        server frontend:80;
+    }
+
     server {
         listen 80;
         server_name _;
@@ -47,8 +51,11 @@ http {
         }
 
         location / {
-            root /usr/share/nginx/html;
-            try_files $uri /index.html;
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix frontend upstream name in outer nginx config
- update dev log

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862a1f2fc388332a292e71e82d2ec77