### PR TITLE
Fix Postgres healthcheck

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,9 @@ SERVER_PORT=4000
 NODE_ENV=development
 JWT_SECRET=change_this_default_secret_at_least_32_chars!
 JWT_REFRESH_SECRET=change_this_refresh_secret_at_least_32_chars!
-POSTGRES_USER=user
-POSTGRES_PASSWORD=password
-DATABASE_URL=postgresql://user:password@postgres:5432/vpn?schema=public
+POSTGRES_USER=vpn
+POSTGRES_PASSWORD=changeme
+DATABASE_URL=postgresql://vpn:changeme@postgres:5432/vpn?schema=public
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 STRIPE_PRICE_BASIC=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
           docker compose build --no-cache
           docker compose up -d
 
+      - name: Check Postgres health
+        run: docker inspect -f '{{.State.Health.Status}}' postgres | grep healthy
+
       - name: Check services start
         run: |
           docker logs backend | grep -q "Server listening"
@@ -86,6 +89,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: docker compose build --no-cache
       - run: docker compose up -d
+      - run: docker inspect -f '{{.State.Health.Status}}' postgres | grep healthy
       - run: curl -sI http://localhost/static/js/main.js | grep -q "Content-Type: application/javascript"
       - run: docker logs nginx   | (! grep -q "host not found")
       - run: docker logs backend | (! grep -qi "libssl")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,14 @@ services:
 # ──────────────────────────── application ───────────────────────────────
   postgres:
     image: postgres:15
-    env_file: ./.env
     environment:
+      POSTGRES_USER: vpn
+      POSTGRES_PASSWORD: changeme
       POSTGRES_DB: vpn
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d postgres"]
       interval: 5s
       retries: 5
     networks: [app]

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -259,3 +259,7 @@
 - Файл `docker-compose.yml` переведён на единый network `app`.
 - `.env.example` теперь содержит параметры PostgreSQL и корректный `DATABASE_URL`.
 - В документацию по логам добавлены рекомендации по ошибке `P1001` и уровню `emerg`.
+
+## 2025-08-24
+- Исправлен healthcheck Postgres в `docker-compose.yml`: теперь используется `pg_isready -U $POSTGRES_USER -d postgres` и заданы переменные `POSTGRES_USER`/`POSTGRES_PASSWORD`.
+- Обновлён `.env.example` и CI, добавлена проверка здоровья Postgres.


### PR DESCRIPTION
## Summary
- set explicit Postgres credentials and improve healthcheck
- keep credentials in `.env.example`
- verify Postgres container health in CI
- log update in `development-log.md`

## Testing
- `docker compose up -d` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c002a6f083328bb4f58e23511f6e