### PR TITLE
Fix backend healthcheck and ensure SubPushQueue migration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,13 +37,12 @@ services:
       postgres:
         condition: service_healthy
     command: >
-      sh -c "sleep 10 && npx prisma migrate deploy &&
+      sh -c "npx prisma migrate deploy &&
              node dist/index.js"
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:4000/health || exit 1"]
+      test: ["CMD-SHELL","curl -sf http://localhost:4000/ | grep OK || exit 1"]
       interval: 10s
       retries: 5
-      start_period: 10s
     networks: [app]
 
   frontend:

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -263,3 +263,9 @@
 ## 2025-08-24
 - Исправлен healthcheck Postgres в `docker-compose.yml`: теперь используется `pg_isready -U $POSTGRES_USER -d postgres` и заданы переменные `POSTGRES_USER`/`POSTGRES_PASSWORD`.
 - Обновлён `.env.example` и CI, добавлена проверка здоровья Postgres.
+
+## 2025-08-25
+- Исправлен healthcheck backend и обновлена команда запуска в docker-compose.
+- Добавлен маршрут `GET /` в Express для проверки контейнера.
+- Сгенерирована миграция Prisma с таблицей `SubPushQueue`.
+

--- a/prisma/migrations/20250630173126_init-sub-push/migration.sql
+++ b/prisma/migrations/20250630173126_init-sub-push/migration.sql
@@ -1,0 +1,116 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('ADMIN', 'USER');
+
+-- CreateEnum
+CREATE TYPE "VpnStatus" AS ENUM ('ONLINE', 'OFFLINE', 'WARNING', 'PENDING');
+
+-- CreateEnum
+CREATE TYPE "AuditAction" AS ENUM ('LOGIN', 'LOGOUT', 'VPN_CREATE', 'VPN_DELETE', 'VPN_RESTART', 'TEMPLATE_EDIT', 'SUBSCRIPTION_STATUS');
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "uuid" TEXT NOT NULL,
+    "role" "Role" NOT NULL DEFAULT 'USER',
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Vpn" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "ownerId" TEXT NOT NULL,
+    "status" "VpnStatus" NOT NULL DEFAULT 'OFFLINE',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Vpn_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Job" (
+    "id" TEXT NOT NULL,
+    "vpnId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "output" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Job_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Subscription" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "stripeSubId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "planId" TEXT NOT NULL,
+    "maxActiveVpns" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Subscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SubscriptionLinkTemplate" (
+    "id" INTEGER NOT NULL DEFAULT 1,
+    "urlTemplate" TEXT NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SubscriptionLinkTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT,
+    "action" "AuditAction" NOT NULL,
+    "payload" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SubPushQueue" (
+    "id" TEXT NOT NULL,
+    "uuid" TEXT NOT NULL,
+    "subString" TEXT NOT NULL,
+    "tries" INTEGER NOT NULL DEFAULT 0,
+    "lastError" TEXT,
+    "nextRetryAt" TIMESTAMP(3),
+
+    CONSTRAINT "SubPushQueue_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_uuid_key" ON "User"("uuid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Subscription_userId_key" ON "Subscription"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Subscription_stripeSubId_key" ON "Subscription"("stripeSubId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SubPushQueue_uuid_key" ON "SubPushQueue"("uuid");
+
+-- AddForeignKey
+ALTER TABLE "Vpn" ADD CONSTRAINT "Vpn_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Job" ADD CONSTRAINT "Job_vpnId_fkey" FOREIGN KEY ("vpnId") REFERENCES "Vpn"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Subscription" ADD CONSTRAINT "Subscription_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -28,6 +28,10 @@ securityMiddlewares.forEach((mw) => app.use(mw));
 app.use(metricsMiddleware);
 mountSwagger(app);
 
+app.get("/", (_req, res) => {
+  res.send("OK");
+});
+
 app.get("/api/health", (_req, res) => {
   res.json({ status: "ok" });
 });


### PR DESCRIPTION
## Summary
- update backend command and healthcheck in `docker-compose.yml`
- add root `GET /` endpoint for container healthcheck
- generate Prisma migration for `SubPushQueue`
- document changes in development log

## Testing
- `npm run lint`
- `npm test`
- `docker compose up -d` *(fails: `docker: command not found`)*
- `curl -s http://localhost:4000/ | grep OK` *(no output)*
- `docker logs backend | grep "Server listening"` *(fails: `docker: command not found`)*
- `docker logs nginx | grep emerg` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862c955af1883328e909ac658dddc57