### PR TITLE
Fix auth context and seed script

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,26 +1,37 @@
-import { PrismaClient } from "@prisma/client";
-import bcrypt from "bcryptjs";
-import crypto from "crypto";
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
 
 const prisma = new PrismaClient();
 
-await prisma.user.create({
-  data: {
-    email: "admin@zerologsvpn.com",
-    passwordHash: bcrypt.hashSync("admin123", 10),
-    uuid: crypto.randomUUID(),
-    role: "ADMIN",
-    nickname: "admin",
-  },
-});
+async function main() {
+  await prisma.user.upsert({
+    where: { email: 'admin@zerologsvpn.com' },
+    update: {},
+    create: {
+      email: 'admin@zerologsvpn.com',
+      passwordHash: bcrypt.hashSync('admin123', 10),
+      uuid: crypto.randomUUID(),
+      role: 'ADMIN',
+      nickname: 'admin',
+    },
+  });
 
-await prisma.subscriptionLinkTemplate.upsert({
-  where: { id: 1 },
-  update: {},
-  create: {
-    id: 1,
-    urlTemplate: "https://sub.example.com/{{UUID}}",
-  },
-});
+  await prisma.subscriptionLinkTemplate.upsert({
+    where: { id: 1 },
+    update: {},
+    create: {
+      id: 1,
+      urlTemplate: 'https://sub.example.com/{{UUID}}',
+    },
+  });
+}
 
-await prisma.$disconnect();
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,55 +1,17 @@
-import React, { createContext, useContext, useState } from 'react';
-import * as auth from '../services/auth';
+import React, { createContext, useContext } from 'react';
+import useAuthHook, { UseAuthReturn } from '../hooks/useAuth';
 
-export interface User {
-  id: string;
-  email: string;
-  nickname?: string;
-}
-
-interface AuthCtx {
-  user: User | null;
-  login(email: string, password: string): Promise<void>;
-  register(email: string, password: string): Promise<void>;
-  logout(): Promise<void>;
-}
-
-const AuthContext = createContext<AuthCtx | null>(null);
+const AuthContext = createContext<UseAuthReturn | null>(null);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [user, setUser] = useState<User | null>(null);
-
-  const login = async (email: string, password: string) => {
-    const res = await auth.login(email, password);
-    if (res.data?.user) {
-      setUser(res.data.user);
-    }
-  };
-
-  const register = async (email: string, password: string) => {
-    const res = await auth.register(email, password);
-    if (res.data?.user) {
-      setUser(res.data.user);
-    }
-  };
-
-  const logout = async () => {
-    await auth.logout();
-    setUser(null);
-  };
-
-  const value: AuthCtx = { user, login, register, logout };
-
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  const auth = useAuthHook();
+  return <AuthContext.Provider value={auth}>{children}</AuthContext.Provider>;
 };
 
-export const useAuth = () => {
+export const useAuth = (): UseAuthReturn => {
   const ctx = useContext(AuthContext);
-  if (!ctx) {
-    throw new Error('useAuth must be used within AuthProvider');
-  }
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
   return ctx;
 };
 
 export default AuthContext;
-

--- a/src/hooks/useAuth.d.ts
+++ b/src/hooks/useAuth.d.ts
@@ -1,0 +1,32 @@
+import { User } from '../types/auth';
+
+export interface AuthResult<T = void> {
+  success: boolean;
+  message?: string;
+  user?: User;
+  error?: string;
+  data?: T;
+}
+
+export interface UseAuthReturn {
+  user: User | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | null;
+  login(email: string, password: string, remember?: boolean): Promise<AuthResult<User>>;
+  register(data: { email: string; password: string }): Promise<AuthResult>;
+  logout(): Promise<void>;
+  refreshToken(): Promise<AuthResult>;
+  updateUser(data: Partial<User & { [key: string]: any }>): void;
+  changePassword(currentPassword: string, newPassword: string): Promise<AuthResult>;
+  resetPassword(email: string): Promise<AuthResult>;
+  hasRole(role: string): boolean;
+  hasPermission(permission: string): boolean;
+  isSubscriptionActive(): boolean;
+  getSubscriptionDaysLeft(): number;
+  clearAuthData(): void;
+  checkAuthStatus(): Promise<void>;
+}
+
+export function useAuth(): UseAuthReturn;
+export default useAuth;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,7 @@
+export interface User {
+  id: string;
+  email: string;
+  nickname?: string;
+  role?: string;
+  [key: string]: any;
+}


### PR DESCRIPTION
## Summary
- use the existing auth hook inside AuthContext
- declare types for the auth hook
- provide User type definition
- rewrite Prisma seed script with async main function

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864d2da5f508332982ae0f0abd27d98