### PR TITLE
Fix PlanCode type in plan service

### DIFF
--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -358,3 +358,7 @@
 - В Dockerfile фронтенда установлена опция `npm install --legacy-peer-deps` для устранения конфликта зависимостей React.
 - Сборка `docker compose build` выполняется без ошибки `ERESOLVE`.
 - Запущены `npm run lint` и `npm test`.
+
+## 2025-09-17
+- Исправлена типизация функции `getPlanByCode` на стороне сервера (используется `PlanCode`).
+- Запущены `npm run lint` и `npm test`.

--- a/server/src/services/planService.ts
+++ b/server/src/services/planService.ts
@@ -1,5 +1,6 @@
+import { PlanCode } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 
-export async function getPlanByCode(code: string) {
+export async function getPlanByCode(code: PlanCode) {
   return prisma.plan.findFirst({ where: { code, isActive: true } });
 }


### PR DESCRIPTION
## Summary
- fix PlanCode typing in `getPlanByCode`
- update development log

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867be03ecb483329d8139457b6f4cd5