### PR TITLE
Fix dotenv initialization order

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,8 +1,8 @@
 import dotenv from "dotenv";
+dotenv.config();
+
 import { app } from "./server";
 import publicPlansRouter from "./routes/publicPlans";
-
-dotenv.config();
 
 const PORT = process.env.SERVER_PORT ? Number(process.env.SERVER_PORT) : 4000;
 


### PR DESCRIPTION
## Summary
- init env vars before importing server

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868c51e04b083329f76a44182b97023