### PR TITLE
Fix Telegram bootstrap and add test

### DIFF
--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -421,3 +421,7 @@
 - Перенесён Telegram init скрипт из index.html в модуль `src/auth/tgInit.ts`.
 - CSP ограничен: разрешены скрипты только с `self` и `https://telegram.org`.
 - Запущены `pnpm run test:unit` и `pnpm run test:e2e`.
+## 2025-09-28
+- Расширен bootstrap в `tgInit.ts`: сохраняет `initData` в localStorage, шлёт событие `telegram-initialized` и вызывает `ready()`.
+- Добавлен тест `tgInit.test.ts`.
+- Запущены `npm run lint` и `npm test`.

--- a/src/auth/tgInit.test.ts
+++ b/src/auth/tgInit.test.ts
@@ -1,0 +1,33 @@
+/** @jest-environment jsdom */
+import { bootstrapFromTelegram } from './tgInit';
+import { setInitParams } from './store';
+
+jest.mock('./store', () => ({
+  setInitParams: jest.fn(),
+}));
+
+describe('bootstrapFromTelegram', () => {
+  beforeEach(() => {
+    (window as any).Telegram = {
+      WebApp: { initData: 'payload', ready: jest.fn() },
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (window as any).Telegram;
+    window.localStorage.clear();
+  });
+
+  it('persists init data and notifies hooks', () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+
+    bootstrapFromTelegram();
+
+    expect(setInitParams).toHaveBeenCalledWith('payload');
+    expect(setItemSpy).toHaveBeenCalledWith('tg_init_data', 'payload');
+    expect(dispatchSpy.mock.calls[0][0].type).toBe('telegram-initialized');
+    expect((window as any).Telegram.WebApp.ready).toHaveBeenCalled();
+  });
+});

--- a/src/auth/tgInit.ts
+++ b/src/auth/tgInit.ts
@@ -1,8 +1,20 @@
 import { setInitParams } from './store';
 
 export function bootstrapFromTelegram() {
-  const initData = (window as any)?.Telegram?.WebApp?.initData || '';
+  const tg = (window as any)?.Telegram?.WebApp;
+  const initData = tg?.initData || '';
+
   if (initData) {
+    // 1. keep it in memory
     setInitParams(initData);
+
+    // 2. persist for other hooks / hard refresh
+    window.localStorage.setItem('tg_init_data', initData);
+
+    // 3. let React hooks know we're ready
+    window.dispatchEvent(new Event('telegram-initialized'));
+
+    // 4. notify Telegram container
+    tg?.ready?.();
   }
 }


### PR DESCRIPTION
## Summary
- expand telegram bootstrap to persist init data and fire event
- add jest test for bootstrapFromTelegram logic
- document changes in development log

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868efc37ca08332ba45ff65f33fb01f