### PR TITLE
fix(auth): accept new Telegram initData fields & allow future keys

### DIFF
--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -434,3 +434,7 @@
 - Все обращения к `window.Telegram.WebApp` обернуты в проверки.
 - README дополнено разделом "Локальная отладка".
 - Запущены `npm run lint` и `npm test` — успешно.
+## 2025-10-01
+- Обновлена схема initData для Bot API 9.0 (device_storage, secure_storage).
+- Добавлен parseInitData с предупреждением об ошибках.
+- Тесты и линт проходят.

--- a/server/test/initDataSchema.spec.ts
+++ b/server/test/initDataSchema.spec.ts
@@ -1,0 +1,21 @@
+/// <reference types="jest" />
+import { parseInitData } from '../../src/utils/telegram/initData';
+
+describe('initDataSchema', () => {
+  it('parses data with device_storage and secure_storage', () => {
+    const raw = 'auth_date=123&hash=abc&device_storage=1&secure_storage=0';
+    const res = parseInitData(raw);
+    expect(res).toEqual({
+      auth_date: '123',
+      hash: 'abc',
+      device_storage: '1',
+      secure_storage: '0',
+    });
+  });
+
+  it('allows extra keys', () => {
+    const raw = 'auth_date=1&hash=2&foo=bar';
+    const res = parseInitData(raw);
+    expect(res).toEqual({ auth_date: '1', hash: '2', foo: 'bar' });
+  });
+});

--- a/src/utils/telegram/initData.ts
+++ b/src/utils/telegram/initData.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const initDataSchema = z
+  .object({
+    query_id: z.string().optional(),
+    user: z.any().optional(),
+    auth_date: z.string(),
+    hash: z.string(),
+    device_storage: z.string().optional(),
+    secure_storage: z.string().optional(),
+  })
+  .passthrough();
+
+export function parseInitData(raw: string) {
+  try {
+    const paramsObj = Object.fromEntries(new URLSearchParams(raw));
+    return initDataSchema.parse(paramsObj);
+  } catch (e) {
+    console.warn('invalid initData', e);
+    if (typeof window !== 'undefined' && (window as any).Sentry?.captureException) {
+      (window as any).Sentry.captureException(e);
+    }
+    return;
+  }
+}


### PR DESCRIPTION
## Summary
- parse Telegram WebApp initData via Zod
- allow optional device_storage and secure_storage fields
- warn on invalid data
- test initData parsing
- document Bot API 9.0 change in dev log

## Testing
- `npm run lint --fix`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6869058f23748332b377866085917b7a