### PR TITLE
feat(auth): dual login (telegram + email/password) & fix /login spinner

### DIFF
--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -438,3 +438,9 @@
 - Обновлена схема initData для Bot API 9.0 (device_storage, secure_storage).
 - Добавлен parseInitData с предупреждением об ошибках.
 - Тесты и линт проходят.
+## 2025-07-05
+- Расширена модель `User` полями `username`, `passwordHash?` и таблицей `RefreshToken`.
+- Реализована функция `issueTokens` и обновлены маршруты аутентификации.
+- В `seed.ts` добавлен демонстрационный пользователь `demo@demo.dev`.
+- Логин-форма автоматически авторизует через Telegram внутри WebApp.
+- Создан `src/api/index.ts` с базовым экземпляром Axios.

--- a/prisma/migrations/20250706120000_add_username_refresh/migration.sql
+++ b/prisma/migrations/20250706120000_add_username_refresh/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "username" TEXT,
+    ALTER COLUMN "email" DROP NOT NULL,
+    ALTER COLUMN "passwordHash" DROP NOT NULL;
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");
+
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "token" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,16 +14,17 @@ enum Role {
 
 model User {
   id              String           @id @default(cuid())
-  email           String           @unique
-  nickname        String?          @unique
+  email           String?          @unique
+  username        String?          @unique
   telegramId      String?          @unique
-  passwordHash    String
+  passwordHash    String?
   uuid            String           @unique
   role            Role             @default(USER)
   preallocatedUid PreallocatedUid?
   Vpn             Vpn[]
   Subscription    Subscription?
   AuditLog        AuditLog[]
+  RefreshToken    RefreshToken[]
 }
 
 model Vpn {
@@ -139,4 +140,12 @@ model Invoice {
   onramperId String?
   createdAt  DateTime      @default(now())
   updatedAt  DateTime      @updatedAt
+}
+
+model RefreshToken {
+  id        String   @id @default(uuid())
+  token     String
+  userId    String
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
 
 const prisma = new PrismaClient();
 
@@ -40,6 +41,19 @@ async function main() {
       { code: 'BASIC_12M', name: '12 мес', priceRub: 4500, durationMo: 12 },
     ],
     skipDuplicates: true,
+  });
+
+  // 3. Demo user
+  await prisma.user.upsert({
+    where: { email: 'demo@demo.dev' },
+    update: {},
+    create: {
+      email: 'demo@demo.dev',
+      username: 'demo',
+      passwordHash: await bcrypt.hash('Demo1234', 10),
+      uuid: predefinedUids[0].uuid,
+      role: 'USER',
+    },
   });
 }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+export const api = axios.create({
+  baseURL: '/api',
+});
+
+export default api;

--- a/src/components/Auth/LoginPage.jsx
+++ b/src/components/Auth/LoginPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { useToast } from '../../contexts/ToastContext';
 import { useNavigate } from 'react-router-dom';
@@ -11,6 +11,19 @@ const LoginPage = () => {
   const { login, register, telegramAuth } = useAuth();
   const navigate = useNavigate();
   const { showToast } = useToast();
+
+  useEffect(() => {
+    const tg = getTelegram();
+    if (tg?.initDataUnsafe?.user && tg?.initDataUnsafe?.hash) {
+      telegramAuth({
+        ...tg.initDataUnsafe.user,
+        auth_date: tg.initDataUnsafe.auth_date,
+        hash: tg.initDataUnsafe.hash,
+      })
+        .then(() => navigate('/dashboard'))
+        .catch(() => {});
+    }
+  }, [navigate, telegramAuth]);
   
   const [isLogin, setIsLogin] = useState(true);
   const [loading, setLoading] = useState(false);
@@ -19,7 +32,7 @@ const LoginPage = () => {
   const [formData, setFormData] = useState({
     login: '',
     email: '',
-    nickname: '',
+    username: '',
     name: '',
     password: '',
     confirmPassword: ''
@@ -53,13 +66,13 @@ const LoginPage = () => {
 
     if (isLogin) {
       if (!formData.login.trim()) {
-        newErrors.login = 'Введите email или nickname';
+        newErrors.login = 'Введите email или username';
       }
     } else {
-      if (!formData.nickname.trim()) {
-        newErrors.nickname = 'Введите nickname';
-      } else if (!validateNickname(formData.nickname)) {
-        newErrors.nickname = 'Nickname должен содержать 3-50 символов (буквы, цифры, _)';
+      if (!formData.username.trim()) {
+        newErrors.username = 'Введите username';
+      } else if (!validateNickname(formData.username)) {
+        newErrors.username = 'Username должен содержать 3-50 символов (буквы, цифры, _)';
       }
 
       if (!formData.name.trim()) {
@@ -104,7 +117,7 @@ const LoginPage = () => {
       if (isLogin) {
         result = await login(formData.login, formData.password);
       } else {
-        result = await register(formData.email, formData.password);
+        result = await register(formData.email, formData.username, formData.password);
       }
 
       if (result?.success) {
@@ -197,16 +210,16 @@ const LoginPage = () => {
                     <User className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
                     <input
                       type="text"
-                      name="nickname"
-                      placeholder="Nickname"
-                      value={formData.nickname}
+                    name="username"
+                    placeholder="Username"
+                    value={formData.username}
                       onChange={handleInputChange}
                       className={`w-full pl-10 pr-4 py-3 bg-gray-700/50 border rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all ${
-                        errors.nickname ? 'border-red-500' : 'border-gray-600'
+                        errors.username ? 'border-red-500' : 'border-gray-600'
                       }`}
                     />
                   </div>
-                  {errors.nickname && <p className="text-red-400 text-sm mt-1">{errors.nickname}</p>}
+                  {errors.username && <p className="text-red-400 text-sm mt-1">{errors.username}</p>}
                 </div>
 
                 <div>
@@ -344,7 +357,7 @@ const LoginPage = () => {
                   setFormData({
                     login: '',
                     email: '',
-                    nickname: '',
+                    username: '',
                     name: '',
                     password: '',
                     confirmPassword: ''

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -51,12 +51,12 @@ export const useAuth = () => {
     }
   }, []);
 
-  const login = useCallback(async (email, password) => {
+  const login = useCallback(async (loginField, password) => {
     try {
       setIsLoading(true);
       setError(null);
 
-      const response = await authApi.login(email, password);
+      const response = await authApi.login(loginField, password);
       const {
         access_token,
         refresh_token,
@@ -106,7 +106,11 @@ export const useAuth = () => {
       setIsLoading(true);
       setError(null);
 
-      const response = await authApi.register(userData.email, userData.password);
+      const response = await authApi.register(
+        userData.email,
+        userData.username,
+        userData.password,
+      );
 
       if (response.success) {
         return { success: true, message: "Регистрация успешна" };

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -5,11 +5,11 @@ const api = axios.create({
   withCredentials: true,
 });
 
-export const login = (email: string, password: string) =>
-  api.post('/auth/login', { email, password });
+export const login = (loginField: string, password: string) =>
+  api.post('/auth/login', { login: loginField, password });
 
-export const register = (email: string, password: string) =>
-  api.post('/auth/register', { email, password });
+export const register = (email: string, username: string, password: string) =>
+  api.post('/auth/register', { email, username, password });
 
 export const telegramAuth = (data: any) =>
   api.post('/auth/telegram', data);


### PR DESCRIPTION
## Summary
- add username and refresh token support in Prisma schema
- seed demo user and update migrations
- implement issueTokens and update auth routes
- support Telegram auto-login and email/username login in LoginPage
- provide Axios SDK and update auth service and hooks
- update UID pool tests and documentation

## Testing
- `npm run lint`
- `npm test`
- ❌ `docker compose up --build` *(fails: `docker-compose: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6869112a29e48332a22ef8064bee591a