### PR TITLE
Fix auth service exports and Telegram login path

### DIFF
--- a/apps/tg-webapp/src/main.tsx
+++ b/apps/tg-webapp/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import TelegramLogin from '../../src/components/Auth/telegram-login';
+import TelegramLogin from '@/components/Auth/telegram-login';
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);
 root.render(

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -482,3 +482,8 @@
 ## 2025-07-06
 - Исправлена сборка приложения main: vite.config.ts теперь использует корневой каталог и абсолютный outDir.
 - Команды `npm run lint` и `npm test` прошли успешно.
+## 2025-10-10
+- Добавлены недостающие методы `refreshToken`, `changePassword`, `resetPassword` в `src/services/auth.ts`.
+- В `tg-webapp` импорт компонента `TelegramLogin` переведён на alias `@`.
+- Сборка `npm run build` завершается успешно.
+

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -16,4 +16,15 @@ export const telegramAuth = (data: any) =>
 
 export const logout = () => api.post('/auth/logout');
 
+export const refreshToken = (refresh: string) =>
+  api.post('/auth/refresh', { refresh });
+
+export const changePassword = (
+  currentPassword: string,
+  newPassword: string,
+) => api.post('/auth/change-password', { currentPassword, newPassword });
+
+export const resetPassword = (email: string) =>
+  api.post('/auth/reset-password', { email });
+
 export default api;


### PR DESCRIPTION
## Summary
- add missing methods to `src/services/auth.ts`
- fix TelegramLogin import in `tg-webapp`
- document build fix in `development-log`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a71c9b064833295badddc1e9392e4