### PR TITLE
Fix docs import path for FAQ and policy pages

### DIFF
--- a/apps/main/src/pages/FaqPage.tsx
+++ b/apps/main/src/pages/FaqPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import MarkdownView from '../components/MarkdownView';
-import faq from '../../docs/faq.md?raw';
+import faq from '../../../docs/faq.md?raw';
 
 const FaqPage: React.FC = () => (
   <div className="min-h-screen bg-gray-900 pt-16 p-6">

--- a/apps/main/src/pages/PrivacyPolicyPage.tsx
+++ b/apps/main/src/pages/PrivacyPolicyPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import MarkdownView from '../components/MarkdownView';
-import policy from '../../docs/privacy-policy.md?raw';
+import policy from '../../../docs/privacy-policy.md?raw';
 
 const PrivacyPolicyPage: React.FC = () => (
   <div className="min-h-screen bg-gray-900 pt-16 p-6">

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -558,3 +558,6 @@
 
 ## 2025-07-15
 - Исправлен Dockerfile backend: копируются src и openapi.yaml, сборка проходит без ошибок.
+
+## 2025-07-15b
+- Исправлены пути импорта markdown-файлов в FaqPage и PrivacyPolicyPage. Сборка Vite теперь проходит без ошибки "Could not resolve".


### PR DESCRIPTION
## Summary
- fix markdown import paths in FAQ and Privacy pages
- update development log

## Testing
- `npx -y npm-run-all lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e973561008332b32d02d959abd552