### PR TITLE
Fix backend Docker build and healthcheck

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,12 @@ Dockerfile.*
 *.log
 *.db-journal
 logs
+apps/main
+apps/tg-webapp
+subscription-server
+crm
+cypress
+public
+deploy
+docs
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,26 +1,30 @@
 ################ build stage ################
-FROM node:18-bullseye AS build
+FROM node:20-alpine AS build
 WORKDIR /app
 
-# зависимости
+
+# установки зависимостей
 COPY package.json pnpm-lock.yaml ./
-RUN corepack enable && pnpm install --frozen-lockfile
+RUN corepack enable \
+    && pnpm install --frozen-lockfile
 
 # исходники
 COPY src ./src
 COPY prisma ./prisma
 COPY openapi.yaml ./openapi.yaml
-RUN pnpm run build:server
-RUN pnpm prisma generate
+RUN pnpm run build:server && \
+    pnpm prisma generate && \
+    pnpm prune --prod
 
 ################ runtime stage ################
-FROM node:18-bullseye
-RUN apt-get update -y \
- && apt-get install -y --no-install-recommends libssl1.1 ca-certificates \
- && rm -rf /var/lib/apt/lists/*
+FROM node:20-alpine
+RUN apk add --no-cache openssl ca-certificates
 
 WORKDIR /app
-COPY --from=build /app .
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/prisma ./prisma
+COPY --from=build /app/openapi.yaml ./openapi.yaml
 
 ENV NODE_ENV=production
 EXPOSE 8080

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -40,6 +40,10 @@ app.get("/", (_req, res) => {
   res.send("OK");
 });
 
+app.get("/healthz", (_req, res) => {
+  res.send("OK");
+});
+
 app.get("/api/health", (_req, res) => {
   res.json({ status: "ok" });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,8 @@ services:
 
   backend:
     build:
-      context: ./apps/server
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: apps/server/Dockerfile
     env_file:
       - ./.env
     depends_on:
@@ -42,7 +42,7 @@ services:
       sh -c "npx prisma migrate deploy &&
              node dist/index.js"
     healthcheck:
-      test: ["CMD-SHELL","curl -sf http://localhost:8080/ | grep OK || exit 1"]
+      test: ["CMD-SHELL","curl -sf http://localhost:8080/healthz | grep OK || exit 1"]
       interval: 10s
       retries: 5
     networks: [app]

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -569,3 +569,8 @@
 - Добавлен алиас `~/docs` в Vite, исправлены пути импорта Markdown.
 - Скрипт для структурированных данных помечен `data-vite-ignore`.
 - Docker-compose теперь использует директорию `apps/server` как контекст.
+
+## 2025-10-20
+- Упрощены Dockerfile и docker-compose: backend собирается из корня, база образов unified на node:20-alpine.
+- Добавлен эндпоинт /healthz и обновлён healthcheck.
+


### PR DESCRIPTION
## Summary
- use Node 20 alpine base for server image
- trim runtime image size and only copy build artifacts
- ignore front-end folders from docker build context
- update compose build context and healthcheck
- expose /healthz route
- log recent DevOps improvements

## Testing
- `pnpm lint`
- `pnpm run build:server`
- `pnpm test`
- `pnpm check:bundle`
- `docker compose build backend` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686eb6e8e64c833293639d2b6b5e277e