### PR TITLE
Fix docker build paths

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,12 +6,10 @@ Dockerfile.*
 *.log
 *.db-journal
 logs
-apps/main
 apps/tg-webapp
 subscription-server
 crm
 cypress
-public
 deploy
 docs
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -4,5 +4,10 @@
   "scripts": {
     "build:server": "ts-node scripts/gen-openapi.ts && tsc -p tsconfig.json",
     "seed": "ts-node prisma/seed.ts"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^4.9.5",
+    "@types/node": "^18.17.0"
   }
 }

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -595,3 +595,9 @@
 - Исправлена сборка фронтенда: `docker-compose` теперь использует корень
   проекта в качестве контекста, чтобы `pnpm` находил `package.json`.
 
+## 2025-07-14
+- В `.dockerignore` перестали исключаться `apps/main` и `public`, сборка фронтенда
+  в Docker больше не падает из-за отсутствия `vite.config.ts`.
+- В `apps/server/package.json` добавлены dev-зависимости `ts-node` и `typescript`,
+  чтобы `pnpm run build:server` выполнялся без ошибок внутри контейнера.
+


### PR DESCRIPTION
## Summary
- fix `.dockerignore` so frontend files are included in Docker build
- add `ts-node` and `typescript` dev dependencies for the server
- document the fixes in development log

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f16d95af08332bfd859d13d1da9de