### PR TITLE
Fix prisma generate in Docker

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -13,7 +13,8 @@ RUN corepack enable \
 COPY ./apps/server ./apps/server
 
 WORKDIR /app/apps/server
-RUN pnpm prisma generate && \
+RUN pnpm install --frozen-lockfile && \
+    npx prisma generate && \
     pnpm run build:server && \
     pnpm prune --prod
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "ts-node": "^10.9.2",
     "typescript": "^4.9.5",
-    "@types/node": "^18.17.0"
+    "@types/node": "^18.17.0",
+    "prisma": "^5.4.0"
   }
 }

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -622,3 +622,10 @@
 - Скрипт `build:server` внутри `apps/server/package.json` теперь запускает только `tsc -p tsconfig.json`.
 - В файлах сервисов типизирован параметр `tx` как `Prisma.TransactionClient`, устранена ошибка `TS7006`.
 - `docker compose build backend --no-cache` завершается без ошибок.
+
+## 2025-10-25
+- В `apps/server/package.json` зависимость `prisma` перенесена в `devDependencies`,
+  чтобы `npx prisma generate` находил бинарник при сборке Docker.
+- В `apps/server/Dockerfile` команда генерации заменена на `npx prisma generate`;
+  перед ней выполняется `pnpm install` внутри каталога сервера.
+- Сборка контейнера `backend` выполняется через `docker compose build backend --no-cache`.


### PR DESCRIPTION
## Summary
- add `prisma` to server devDependencies
- run `pnpm install` inside server before Prisma generation
- use `npx prisma generate` in the backend Dockerfile
- document changes in `development-log`

## Testing
- `npm run lint`
- `docker compose build backend --no-cache` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870a18358d08332a28eb7526e819b37