### PR TITLE
Fix prisma build errors

### DIFF
--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -634,3 +634,6 @@
 - Починен билд backend: ошибка TS2339 в `VpnModel` устранена кастом через `as any`.
 - Выполнены `prisma generate` и `pnpm run build:server` без ошибок.
 
+## 2025-10-26
+- Добавлены модели `UserCheckSecret` и `BuildTag` в Prisma schema.
+- Выполнены `prisma generate` и `pnpm run build:server` без ошибок.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model User {
   RefreshToken    RefreshToken[]
   telegram        TelegramAccount?
   creds           Credentials?
+  checkSecret     UserCheckSecret?
 }
 
 model Vpn {
@@ -168,4 +169,16 @@ model Credentials {
   email   String @unique
   passHash String
   user    User   @relation(fields: [userId], references: [id])
+}
+
+model UserCheckSecret {
+  userId String @id
+  secret String
+  user   User   @relation(fields: [userId], references: [id])
+}
+
+model BuildTag {
+  id        Int      @id @default(autoincrement())
+  tag       String   @unique
+  createdAt DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- add UserCheckSecret and BuildTag models in prisma schema
- document schema update in development log

## Testing
- `pnpm prisma generate`
- `pnpm run build:server`
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6870ad4eaf3c8332b3505b6b07b59892