### PR TITLE
Separate server build tsconfig

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,7 +2,7 @@
   "name": "vpn-backend",
   "private": true,
   "scripts": {
-    "build:server": "prisma generate && tsc -p .",
+    "build:server": "prisma generate && tsc -p tsconfig.build.json",
     "seed": "ts-node prisma/seed.ts"
   },
   "devDependencies": {

--- a/apps/server/tsconfig.build.json
+++ b/apps/server/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -650,3 +650,8 @@
 - В `Dockerfile.frontend` копируется новый конфиг.
 - Компонент `AuthPage` проверяет наличие Telegram WebApp.
 - GitHub Actions собирает контейнеры через `docker compose`, запускает smoke-тесты и пушит образы при успехе.
+
+## 2025-10-29
+- Создан `tsconfig.build.json` в `apps/server` для продакшн сборки.
+- Скрипт `build:server` теперь использует этот конфиг.
+- `pnpm --filter apps/server run build:server` проходит без ошибок.


### PR DESCRIPTION
## Summary
- add tsconfig.build.json for server production build
- use new config in server build script
- log doc entry about the new config

## Testing
- `pnpm run build:server` in `apps/server`
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68710f95c9708332b664db21149c100e