### PR TITLE
Fix docker compose and prisma client path

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -29,5 +29,5 @@ COPY --from=build /app/prisma ./prisma
 COPY --from=build /app/apps/server/openapi.yaml ./openapi.yaml
 
 ENV NODE_ENV=production
-EXPOSE 8080
+EXPOSE 4000
 CMD ["node", "dist/index.js"]

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "build:server": "prisma generate && tsc -p tsconfig.build.json",
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "ts-node prisma/seed.ts",
+    "start": "node dist/index.js"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     networks: [app]
 
   backend:
+    container_name: backend
     build:
       context: .
       dockerfile: apps/server/Dockerfile
@@ -43,15 +44,16 @@ services:
       sh -c "npx prisma migrate deploy &&
              node dist/index.js"
     healthcheck:
-      test: ["CMD-SHELL","curl -sf http://localhost:8080/healthz | grep OK || exit 1"]
+      test: ["CMD-SHELL","curl -sf http://localhost:4000/healthz | grep OK || exit 1"]
       interval: 10s
       retries: 5
     networks: [app]
     ports:
-      - 8080:8080
+      - 4000:4000
 
 
   frontend:
+    container_name: frontend
     build:
       context: .
       dockerfile: Dockerfile.frontend

--- a/docker/frontend/nginx/default.conf
+++ b/docker/frontend/nginx/default.conf
@@ -1,3 +1,9 @@
-location / {
-    try_files $uri /index.html;
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+    location / {
+        try_files $uri /index.html;
+    }
 }

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -655,3 +655,9 @@
 - Создан `tsconfig.build.json` в `apps/server` для продакшн сборки.
 - Скрипт `build:server` теперь использует этот конфиг.
 - `pnpm --filter apps/server run build:server` проходит без ошибок.
+
+## 2025-10-30
+- Исправлены имена сервисов и порты в `docker-compose.yml`.
+- Обновлены upstream в `nginx.conf` и конфиг SPA `docker/frontend/nginx/default.conf`.
+- Prisma Client теперь генерируется в `apps/server/dist/.prisma`.
+- В `apps/server/package.json` добавлен скрипт `start`.

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -18,12 +18,11 @@ http {
     add_header Content-Security-Policy "script-src 'self' https://telegram.org" always;
 
 
-    upstream api {
+    upstream backend {
         server backend:4000;
     }
 
     upstream frontend {
-        # frontend сервис теперь называется vpn-frontend
         server frontend:80;
     }
 
@@ -51,7 +50,7 @@ http {
         ssl_ciphers HIGH:!aNULL:!MD5;
 
         location /api/ {
-            proxy_pass http://backend:4000;
+            proxy_pass http://backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -60,7 +59,7 @@ http {
 
         # Public plans endpoint
         location /plans {
-            proxy_pass http://backend:4000/api/public/plans;
+            proxy_pass http://backend/api/public/plans;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -91,7 +90,7 @@ http {
         ssl_ciphers HIGH:!aNULL:!MD5;
 
         location /api/ {
-            proxy_pass http://backend:4000;
+            proxy_pass http://backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -114,7 +113,7 @@ http {
         ssl_ciphers HIGH:!aNULL:!MD5;
 
         location /api/ {
-            proxy_pass http://backend:4000;
+            proxy_pass http://backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -123,7 +122,7 @@ http {
 
         # Public plans endpoint
         location /plans {
-            proxy_pass http://backend:4000/api/public/plans;
+            proxy_pass http://backend/api/public/plans;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,6 +5,7 @@ datasource db {
 
 generator client {
   provider = "prisma-client-js"
+  output   = "../dist/.prisma/client"
 }
 
 enum Role {


### PR DESCRIPTION
## Summary
- set container_name and health check ports in docker-compose
- simplify nginx upstream usage
- update frontend nginx config for SPA
- generate prisma client into dist directory
- expose 4000 in backend Dockerfile and add start script
- note changes in development log

## Testing
- `npm run lint`
- `npm test`
- `docker compose` commands *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871130ef4f08332b1e6edb1737ccf73