### PR TITLE
Fix Prisma client output path

### DIFF
--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -684,3 +684,7 @@
 ## 2025-07-15
 - Модели `PlanCache` и `PlanUse` теперь ссылаются на `Plan.code` и `User.id`. Клиент Prisma пересоздан.
 
+## 2025-07-16
+- Исправлена генерация Prisma Client: вывод снова в `node_modules/@prisma/client`.
+- Сборка `pnpm run build:server` завершается без ошибок.
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,7 +5,6 @@ datasource db {
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../dist/.prisma/client"
 }
 
 enum Role {


### PR DESCRIPTION
## Summary
- use default path for Prisma client generation
- log fix in development log

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68714a3c3bd883329e60b29173edbeeb