### PR TITLE
Fix docker compose build

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -28,6 +28,7 @@ COPY --from=deps /app/pnpm-lock.yaml /app/package.json ./
 ENV PATH=/app/node_modules/.bin:$PATH
 # ▾ Копируем реальные исходники после deps-кэша
 COPY apps/server ./apps/server
+COPY apps/server/openapi.yaml apps/server/openapi.yaml
 COPY prisma      ./prisma
 
 # Генерируем Prisma и компилируем TypeScript

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
 # ──────────────────────────── infrastructure ────────────────────────────
   nginx:

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -697,3 +697,8 @@
 - Файл `openapi.yaml` не копировался в финальный слой образа.
 - В `apps/server/Dockerfile` добавлена строка `COPY --from=build-backend /app/apps/server/openapi.yaml ./openapi.yaml`.
 - Теперь сервер стартует без ошибки и документация Swagger доступна в режиме разработки.
+
+## 2025-11-03
+- Удалена директива `version` из `docker-compose.yml` — Docker больше не предупреждает об устаревшей схеме.
+- `apps/server/Dockerfile` теперь отдельно копирует `openapi.yaml` на этапе сборки.
+- Дополнен раздел `/docs` — фиксация изменений помогает отслеживать проблемы сборки.


### PR DESCRIPTION
## Summary
- copy openapi.yaml explicitly during backend build
- drop obsolete `version` key from compose file
- log docker adjustments in development-log

## Testing
- `docker compose build --no-cache backend` *(fails: command not found)*
- `docker compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871ac4468d083329f1d89152cfa02f7