### PR TITLE
fix(build): correct prisma path

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,7 +2,7 @@
   "name": "vpn-backend",
   "private": true,
   "scripts": {
-    "build:server": "npx prisma generate --schema=../prisma/schema.prisma && tsc -p tsconfig.build.json",
+    "build:server": "npx prisma generate --schema=./prisma/schema.prisma && tsc -p tsconfig.build.json",
     "seed": "ts-node prisma/seed.ts",
     "start": "node dist/index.js"
   },

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -760,3 +760,8 @@
   генерация выполняется через `npx`.
 - `apps/server/Dockerfile` теперь вызывает `npx prisma generate` и `pnpm exec tsc`
   вместо `pnpm --filter`.
+
+## 2025-07-22
+- Снова возникла ошибка `ENOTDIR` в Docker при `pnpm run build:server`.
+- Путь к `schema.prisma` изменён на `./prisma/schema.prisma` для надёжной работы
+  в контейнере.


### PR DESCRIPTION
## Summary
- fix prisma path in `build:server` script so Docker builds find the schema
- record fix in `development-log.md`

## Testing
- `pnpm run lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687a14af08e48332a85d8a7491c43fae