### PR TITLE
Fix Docker build for backend

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -30,6 +30,9 @@ ENV PATH=/app/node_modules/.bin:$PATH
 COPY apps/server ./apps/server
 COPY apps/server/openapi.yaml apps/server/openapi.yaml
 COPY prisma      ./prisma
+# также копируем схему в каталог приложения,
+# иначе при сборке возникает ошибка ENOTDIR
+COPY prisma      ./apps/server/prisma
 
 # Генерируем Prisma и компилируем TypeScript
 RUN npx prisma generate --schema=prisma/schema.prisma && pnpm exec tsc -p apps/server/tsconfig.build.json

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -765,3 +765,7 @@
 - Снова возникла ошибка `ENOTDIR` в Docker при `pnpm run build:server`.
 - Путь к `schema.prisma` изменён на `./prisma/schema.prisma` для надёжной работы
   в контейнере.
+
+## 2025-07-18
+- Для предотвращения ошибки `ENOTDIR` в Dockerfile сервера копируем каталог
+  `prisma` как в корень образа, так и в `apps/server/prisma` перед сборкой.


### PR DESCRIPTION
## Summary
- ensure Prisma schema is present when building backend container
- note ENOTDIR fix in development log

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687a183c1344833294315782c23c8fb4