### PR TITLE
Fix Docker build for backend

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -28,11 +28,12 @@ COPY --from=deps /app/pnpm-lock.yaml /app/package.json ./
 ENV PATH=/app/node_modules/.bin:$PATH
 # ▾ Копируем реальные исходники после deps-кэша
 COPY apps/server ./apps/server
+RUN rm -f apps/server/prisma && mkdir -p apps/server/prisma
 COPY apps/server/openapi.yaml apps/server/openapi.yaml
-COPY prisma      ./prisma
-# также копируем схему в каталог приложения,
-# иначе при сборке возникает ошибка ENOTDIR
-COPY prisma      ./apps/server/prisma
+# Каталог с Prisma должен существовать до копирования,
+# иначе Docker выдаёт "cannot copy to non-directory"
+COPY prisma ./prisma
+COPY prisma ./apps/server/prisma
 
 # Генерируем Prisma и компилируем TypeScript
 RUN npx prisma generate --schema=prisma/schema.prisma && pnpm exec tsc -p apps/server/tsconfig.build.json

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -941,3 +941,9 @@
 - Dockerfile фронтенда переведён на node:18-alpine.
 - Добавлен временный компонент TelegramLogin для tg-webapp.
 - `pnpm build` и тесты выполняются без ошибок.
+
+## 2025-10-11
+
+- В `apps/server/Dockerfile` каталог `apps/server` создаётся до копирования `prisma`.
+- Символическая ссылка `apps/server/prisma` заменена на реальную директорию,
+  чтобы избежать ошибки "cannot copy to non-directory" при сборке Docker.


### PR DESCRIPTION
## Summary
- fix Dockerfile backend to always create the `apps/server` folder before copying Prisma
- document Docker build fix in the development log

## Testing
- `pnpm run lint`
- ❌ `docker compose build` *(docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a401594688332a25f672ff948d0ef