### PR TITLE
Remove duplicate prisma copy step

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -32,8 +32,8 @@ RUN rm -f apps/server/prisma && mkdir -p apps/server/prisma
 COPY apps/server/openapi.yaml apps/server/openapi.yaml
 # Каталог с Prisma должен существовать до копирования,
 # иначе Docker выдаёт "cannot copy to non-directory"
+# Каталог копируем только один раз
 COPY prisma ./prisma
-COPY prisma ./apps/server/prisma
 
 # Генерируем Prisma и компилируем TypeScript
 RUN npx prisma generate --schema=prisma/schema.prisma && pnpm exec tsc -p apps/server/tsconfig.build.json

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -947,3 +947,7 @@
 - В `apps/server/Dockerfile` каталог `apps/server` создаётся до копирования `prisma`.
 - Символическая ссылка `apps/server/prisma` заменена на реальную директорию,
   чтобы избежать ошибки "cannot copy to non-directory" при сборке Docker.
+## 2025-10-15
+
+- Удалена лишняя строка копирования каталога prisma в Dockerfile бекенда.
+


### PR DESCRIPTION
## Summary
- fix Docker build by copying `prisma` directory only once
- log this change in development log

## Testing
- `pnpm run lint`
- `pnpm test`
- `docker compose build backend --no-cache` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a486970bc8332b3ecb2f13eadc4fa