### PR TITLE
ci: add docker smoke workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,111 @@
+name: CI (build + smoke)
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image and LOAD into runner
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: app:ci
+          load: true
+
+      - name: Create CI docker network
+        run: |
+          set -euo pipefail
+          docker network create ci-net || true
+
+      - name: Start Postgres (service)
+        run: |
+          set -euo pipefail
+          docker run -d --rm --name db --network ci-net \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_DB=test \
+            -p 5432:5432 \
+            --health-cmd="pg_isready -U postgres -d test" \
+            --health-interval=2s --health-timeout=2s --health-retries=60 \
+            postgres:16-alpine
+
+      - name: Wait for Postgres to be healthy
+        shell: bash
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 120); do
+            status=$(docker inspect -f '{{.State.Health.Status}}' db || echo starting)
+            if [ "$status" = "healthy" ]; then echo "ok"; exit 0; fi
+            sleep 1
+          done
+          echo "Postgres did not become healthy in time" >&2
+          docker logs db || true
+          exit 1
+
+      - name: Start app container
+        run: |
+          set -euo pipefail
+          docker run -d --rm --name app-ci --network ci-net -p 5173:5173 \
+            -e NODE_ENV=production \
+            -e DB_DRIVER=pg \
+            -e DB="postgresql://postgres:postgres@db:5432/test?sslmode=disable" \
+            -e SESSION_SECRET="ci" \
+            -e NEXT_PUBLIC_APP_BASE_URL="http://127.0.0.1:5173" \
+            -e PUBLIC_APP_ORIGIN="http://127.0.0.1:5173" \
+            app:ci
+
+      - name: Wait for /healthz
+        shell: bash
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 120); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:5173/healthz || true)
+            if [ "$code" = "200" ]; then exit 0; fi
+            sleep 1
+          done
+          echo "App /healthz is not ready" >&2
+          docker logs app-ci || true
+          exit 1
+
+      - name: "Smoke: /api/auth/login must NOT be 404"
+        shell: bash
+        run: |
+          set -euo pipefail
+          code=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST http://127.0.0.1:5173/api/auth/login \
+            -H "content-type: application/json" -d '{}' || true)
+          if [ "$code" = "404" ]; then
+            echo "/api/auth/login returned 404" >&2
+            docker logs app-ci || true
+            exit 1
+          fi
+          echo "login status=$code (ок, главное не 404)"
+
+      - name: Dump logs & Cleanup
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "--- app logs:"; docker logs app-ci 2>/dev/null || true
+          echo "--- db logs:"; docker logs db 2>/dev/null || true
+          docker rm -f app-ci 2>/dev/null || true
+          docker rm -f db 2>/dev/null || true
+          docker network rm ci-net 2>/dev/null || true

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -981,3 +981,9 @@
 - В `docker-compose.yml` добавлен монтируемый скрипт `db/init-hanko.sql` для создания схемы.
 - Сервисы `hanko` и `hanko-migrate` получают переменную `HANKO_DB_CONNECTION_STRING`.
 - README дополнено новой переменной и инструкцией по работе со схемой.
+
+## 2026-07-26
+
+- Добавлен workflow `.github/workflows/docker.yml` для сборки Docker-образа и смоук-тестов.
+- Workflow поднимает Postgres и приложение, проверяет `/healthz` и отсутствие 404 на `/api/auth/login`.
+- При падении тестов выводятся логи контейнеров.


### PR DESCRIPTION
## Summary
- add GH Actions workflow to build Docker image and run smoke tests
- document workflow addition in development log

## Testing
- `yamllint -d "{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}" .github/workflows/docker.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a4e40ab1988332a831f5e1cf039e3b